### PR TITLE
Chore(ci-cd): add spotless check job.

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
+      - name: Check spotless
+        run: ./gradlew spotlessCheck --init-script gradle/init.gradle.kts --no-configuration-cache
+
       - name: Build all build type and flavor permutations
         run: ./gradlew assemble
 


### PR DESCRIPTION
- Added a new CI job to ensure code formatting with spotlessCheck.
- Used --init-script to specify the initialization script.
- Disabled configuration cache with --no-configuration-cache for accuracy.